### PR TITLE
fix: update deployment endpoint

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -37,7 +37,7 @@ jobs:
             DOCKER_REPO: screwdrivercd/buildcluster-queue-worker
             K8S_CONTAINER: screwdriver-buildcluster-queue-worker
             K8S_IMAGE: screwdrivercd/buildcluster-queue-worker
-            K8S_HOST: api.k8s.screwdriver.cd
+            K8S_HOST: api.ossd.k8s.screwdriver.cd
             K8S_DEPLOYMENT: buildcluster-queue-worker-beta
         secrets:
             # Talking to Kubernetes


### PR DESCRIPTION
 Previously we point `api.k8s.screwdriver.cd`  to the ips for `api.ossd.k8s.screwdriver.cd` in AWS route53. That means whenever we update the cluster, manual change is needed. Switch to the correct endpoint.