### PR TITLE
fix: set the correct tag for docker trigger

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,22 +11,26 @@ jobs:
     publish:
         requires: main
         template: screwdriver-cd/semantic-release
-        steps:
-            - postpublish: git clone https://github.com/screwdriver-cd/toolbox.git ci && ./ci/git-latest.sh && DOCKER_TAG=`cat VERSION` ./ci/docker-trigger.sh
-        environment:
-            # Docker hub repo
-            DOCKER_REPO: screwdrivercd/buildcluster-queue-worker
         secrets:
             # Publishing to NPM
             - NPM_TOKEN
             # Pushing tags to Git
             - GH_TOKEN
+            
+    docker-trigger:
+        requires: publish
+        steps:
+            - trigger: git clone https://github.com/screwdriver-cd/toolbox.git ci && ./ci/git-latest.sh && DOCKER_TAG=`cat VERSION` ./ci/docker-trigger.sh
+        environment:
+            # Docker hub repo
+            DOCKER_REPO: screwdrivercd/buildcluster-queue-worker
+        secrets:
             # Trigger a Docker Hub build
             - DOCKER_TRIGGER
 
     # Deploy to beta environment
     beta:
-        requires: [publish]
+        requires: docker-trigger
         steps:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - get-tag: ./ci/git-latest.sh


### PR DESCRIPTION
when doing docker trigger and publish in the same build, it won't be able to get the new tag since the cmd is doing `git tags` from the current repo which doesn't include the new tag that got pushed by semantic-release