### PR TITLE
fix(1830): add cache strategy and cache path environment variables

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -164,6 +164,11 @@ executor:
         # Interval to detect the stopped job (seconds)
         cleanupWatchInterval: EXECUTOR_JENKINS_CLEANUP_WATCH_INTERVAL
 
+# build cache strategies: s3, disk, with s3 as default option to store cache
+cache:
+    strategy: CACHE_STRATEGY
+    path: CACHE_PATH
+
 ecosystem:
     # URL for the User Interface
     ui: ECOSYSTEM_UI

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -101,6 +101,12 @@ executor:
 #             # Default max build timeout (in minutes)
 #             maxBuildTimeout: 120
 
+
+# build cache strategies: s3, disk, with s3 as default option to store cache
+cache:
+    strategy: s3
+    path: ""
+
 ecosystem:
     # Externally routable URL for the User Interface
     ui: https://cd.screwdriver.cd


### PR DESCRIPTION
## Context

cache strategy and cache path environment variables missing for disk cache strategy

## Objective

add missing cache strategy and cache path environment variables for disk cache strategy

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
