### PR TITLE
fix(1830): update cache env var path and latest executork8svm

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -178,6 +178,10 @@ ecosystem:
     store: ECOSYSTEM_STORE
     # Pushgateway URL for Prometheus
     pushgatewayUrl: ECOSYSTEM_PUSHGATEWAY_URL
+    # build cache strategies: s3, disk, with s3 as default option to store cache
+    cache:
+        strategy: CACHE_STRATEGY
+        path: CACHE_PATH
 
 rabbitmq:
     # Protocol for rabbitmq server, use amqps for ssl

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -114,6 +114,10 @@ ecosystem:
     api: https://api.screwdriver.cd
     # Externally routable URL for the Artifact Store
     store: https://store.screwdriver.cd
+    # build cache strategies: s3, disk, with s3 as default option to store cache
+    cache:
+        strategy: s3
+        path: "/"
 
 rabbitmq:
     # Protocol for rabbitmq server, use amqps for ssl

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -116,7 +116,7 @@ ecosystem:
     store: https://store.screwdriver.cd
     # build cache strategies: s3, disk, with s3 as default option to store cache
     cache:
-        strategy: s3
+        strategy: "s3"
         path: "/"
 
 rabbitmq:

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "path": "^0.12.7",
     "request": "^2.88.0",
     "screwdriver-executor-k8s": "^13.6.1",
-    "screwdriver-executor-k8s-vm": "^3.1.1",
+    "screwdriver-executor-k8s-vm": "^3.1.2",
     "screwdriver-executor-router": "^1.0.11",
     "screwdriver-logger": "^1.0.0",
     "threads": "^0.12.1"


### PR DESCRIPTION
## Context

Move cache environment variables under ecosystem and get latest executork8svm

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
