### PR TITLE
fix(1830): add cache2disk md5, compress, maxsize env var

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -182,6 +182,9 @@ ecosystem:
     cache:
         strategy: CACHE_STRATEGY
         path: CACHE_PATH
+        compress: CACHE_COMPRESS
+        md5check: CACHE_MD5CHECK
+        max_size_mb: CACHE_MAX_SIZE_MB
 
 rabbitmq:
     # Protocol for rabbitmq server, use amqps for ssl

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -118,6 +118,9 @@ ecosystem:
     cache:
         strategy: "s3"
         path: "/"
+        compress: false
+        md5check: false
+        max_size_mb: 0
 
 rabbitmq:
     # Protocol for rabbitmq server, use amqps for ssl

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "path": "^0.12.7",
     "request": "^2.88.0",
     "screwdriver-executor-k8s": "^13.6.1",
-    "screwdriver-executor-k8s-vm": "^3.1.2",
+    "screwdriver-executor-k8s-vm": "^3.1.3",
     "screwdriver-executor-router": "^1.0.11",
     "screwdriver-logger": "^1.0.0",
     "threads": "^0.12.1"


### PR DESCRIPTION
## Objective

add md5 check, compress, max limit environment variables for local cache

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
