### PR TITLE
fix(1887): fix cache folder permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "path": "^0.12.7",
     "request": "^2.88.0",
     "screwdriver-executor-k8s": "^13.6.1",
-    "screwdriver-executor-k8s-vm": "^3.1.4",
+    "screwdriver-executor-k8s-vm": "^3.2.1",
     "screwdriver-executor-router": "^1.0.11",
     "screwdriver-logger": "^1.0.0",
     "threads": "^0.12.1"


### PR DESCRIPTION
## Context

Build cache fails with error "permission denied in set cache" when using disk-based strategy, due to permission issue on created folders.

## Objective

This PR pulls latest executor-k8s-vm which has the fix for cache folder permissions

## References

[1887](https://github.com/screwdriver-cd/screwdriver/issues/1887)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
