### PR TITLE
feat(818): Enable privileged mode for kata containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mockery": "^2.1.0",
     "path": "^0.12.7",
     "request": "^2.88.0",
-    "screwdriver-executor-k8s": "^13.7.0",
+    "screwdriver-executor-k8s": "^13.8.0",
     "screwdriver-executor-k8s-vm": "^3.2.2",
     "screwdriver-executor-router": "^1.0.11",
     "screwdriver-logger": "^1.0.0",


### PR DESCRIPTION
## Context

Enable kata containers to run in privileged mode 

## Objective

Pull in the latest executor-k8s which has changes related to enabling privileged mode for kata containers.

## References

[Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
