### PR TITLE
feat(818): Security Context privileged mode configurable via a flag by admin

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -9,7 +9,7 @@ executor:
         kubernetes:
             # The host or IP of the kubernetes cluster
             host: K8S_HOST
-            # Privileged mode, default restricted, set to true for DIND use-case
+            # Privileged mode, default restricted, set to true for trusted container runtime use-case
             privileged: K8S_SECURITYCONTEXT_PRIVILEGED
             # The jwt token used for authenticating kubernetes requests
             token: K8S_TOKEN

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -75,7 +75,7 @@ executor:
         kubernetes:
             # The host or IP of the kubernetes cluster
             host: K8S_HOST
-            # Privileged mode, default restricted, set to true for DIND use-case
+            # Privileged mode, default restricted, set to true for trusted container runtime use-case
             privileged: K8S_SECURITYCONTEXT_PRIVILEGED
             # The jwt token used for authenticating kubernetes requests
             token: K8S_TOKEN

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -9,6 +9,8 @@ executor:
         kubernetes:
             # The host or IP of the kubernetes cluster
             host: K8S_HOST
+            # Privileged mode, default restricted, set to true for DIND use-case
+            privileged: K8S_SECURITYCONTEXT_PRIVILEGED
             # The jwt token used for authenticating kubernetes requests
             token: K8S_TOKEN
             jobsNamespace: K8S_JOBS_NAMESPACE
@@ -73,6 +75,8 @@ executor:
         kubernetes:
             # The host or IP of the kubernetes cluster
             host: K8S_HOST
+            # Privileged mode, default restricted, set to true for DIND use-case
+            privileged: K8S_SECURITYCONTEXT_PRIVILEGED
             # The jwt token used for authenticating kubernetes requests
             token: K8S_TOKEN
             jobsNamespace: K8S_JOBS_NAMESPACE

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -7,7 +7,7 @@ executor:
         kubernetes:
             # The host or IP of the kubernetes cluster
             host: kubernetes.default
-            # Privileged mode, default restricted, set to true for DIND use-case
+            # Privileged mode, default restricted, set to true for trusted container runtime use-case
             privileged: false
             dockerFeatureEnabled: false
             resources:
@@ -51,7 +51,7 @@ executor:
         kubernetes:
             # The host or IP of the kubernetes cluster
             host: kubernetes.default
-            # Privileged mode, default restricted, set to true for DIND use-case
+            # Privileged mode, default restricted, set to true for trusted container runtime use-case
             privileged: false
             # Resources for build pod
             resources:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -7,6 +7,8 @@ executor:
         kubernetes:
             # The host or IP of the kubernetes cluster
             host: kubernetes.default
+            # Privileged mode, default restricted, set to true for DIND use-case
+            privileged: false
             dockerFeatureEnabled: false
             resources:
                 cpu:
@@ -49,6 +51,8 @@ executor:
         kubernetes:
             # The host or IP of the kubernetes cluster
             host: kubernetes.default
+            # Privileged mode, default restricted, set to true for DIND use-case
+            privileged: false
             # Resources for build pod
             resources:
                 cpu:

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mockery": "^2.1.0",
     "path": "^0.12.7",
     "request": "^2.88.0",
-    "screwdriver-executor-k8s": "^13.8.0",
+    "screwdriver-executor-k8s": "^13.9.0",
     "screwdriver-executor-k8s-vm": "^3.2.2",
     "screwdriver-executor-router": "^1.0.11",
     "screwdriver-logger": "^1.0.0",


### PR DESCRIPTION
## Context

By default, k8s pod runs in privileged mode.

## Objective

Privileged mode is enabled via a flag by admin

## References

[Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
