### PR TITLE
feat: config for serviceAccount and automountServiceAccountToken

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -14,6 +14,9 @@ executor:
             # The jwt token used for authenticating kubernetes requests
             token: K8S_TOKEN
             jobsNamespace: K8S_JOBS_NAMESPACE
+            # Preferable to use service account instead of token secret
+            serviceAccount: K8S_SERVICE_ACCOUNT_NAME
+            automountServiceAccountToken: K8S_AUTOMOUNT_SERVICE_ACCOUNT_TOKEN
             # feature flag to enable docker in docker
             dockerFeatureEnabled: DOCKER_FEATURE_ENABLED
             # Resources for build pod

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -9,6 +9,7 @@ executor:
             host: kubernetes.default
             # Privileged mode, default restricted, set to true for trusted container runtime use-case
             privileged: false
+            automountServiceAccountToken: false
             dockerFeatureEnabled: false
             resources:
                 cpu:


### PR DESCRIPTION
## Context

make options for service account and automount token as a preferable option for attaching service account instead of overriding token

## Objective

add config for service account and automount token

## References

https://github.com/screwdriver-cd/screwdriver/issues/1955
https://github.com/screwdriver-cd/executor-k8s/pull/116

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
