### PR TITLE
feat(818): add runtimeclass config for kata

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -57,6 +57,8 @@ executor:
             annotations:
               __name: K8S_ANNOTATIONS
               __format: json
+            # support for kata-containers-as-a-runtimeclass
+            runtimeClass: K8S_RUNTIME_CLASS
         # Launcher image to use
         launchImage: LAUNCH_IMAGE
         # Launcher container tag to use

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -32,6 +32,8 @@ executor:
             nodeSelectors: {}
             preferredNodeSelectors: {}
             annotations: {}
+            # support for kata-containers-as-a-runtimeclass
+            runtimeClass: ""
         # Launcher image to use
         launchImage: screwdrivercd/launcher
         # Container tags to use

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mockery": "^2.1.0",
     "path": "^0.12.7",
     "request": "^2.88.0",
-    "screwdriver-executor-k8s": "^13.12.0",
+    "screwdriver-executor-k8s": "^13.14.0",
     "screwdriver-executor-k8s-vm": "^3.2.2",
     "screwdriver-executor-router": "^1.0.11",
     "screwdriver-logger": "^1.0.0",


### PR DESCRIPTION
## Context

Add runtime class config to support kata for kubernetes version v1.12.0 or above [kata-containers-as-a-runtimeclass](https://github.com/kata-containers/documentation/blob/master/how-to/containerd-kata.md#kata-containers-as-a-runtimeclass).

## References

[Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)
[executor-k8s PR#121](https://github.com/screwdriver-cd/executor-k8s/pull/121)


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.