### PR TITLE
fix(2087): cachestrategy and cachepath declaration

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -24,8 +24,8 @@ function getConfig() {
         queueOptions,
         prefetchCount: Number(prefetchCount),
         messageReprocessLimit: Number(messageReprocessLimit),
-        strategy,
-        path
+        cacheStrategy: strategy,
+        cachePath: path
     };
 }
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -69,8 +69,8 @@ describe('config test', () => {
             queueOptions: configDef.rabbitmq.queueOptions,
             prefetchCount: configDef.rabbitmq.prefetchCount,
             messageReprocessLimit: configDef.rabbitmq.messageReprocessLimit,
-            strategy: configDef.ecosystem.cache.strategy,
-            path: configDef.ecosystem.cache.path
+            cacheStrategy: configDef.ecosystem.cache.strategy,
+            cachePath: configDef.ecosystem.cache.path
         });
     });
 


### PR DESCRIPTION
## Context

Fix cacheStrategy and cachePath var declaration

## References

[Cache cleanup is broken when disk-based cache is used](https://github.com/screwdriver-cd/screwdriver/issues/2087)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
