### PR TITLE
fix(2087): upgrade node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:12
 
 # Screwdriver Queue Worker Version
 ARG VERSION=latest

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ const onMessage = (data) => {
                 const threadCache = spawn('./lib/cache.js');
                 const job = `jobType: ${messageType.resource}, action: ${messageType.action}, ` +
                             `cacheStrategy: ${cacheStrategy}, cachePath: ${cachePath}, ` +
-                            ` prefix: ${messageType.prefix}, entity: ${messageType.scope}, ` +
+                            ` prefix: ${messageType.prefix}, scope: ${messageType.scope}, ` +
                             ` id: ${messageType.id}`;
 
                 logger.info(`processing ${job}`);


### PR DESCRIPTION
## Context

fs-extra module fails with `/usr/src/app/node_modules/fs-extra/lib/mkdirs/make-dir.js:85 } catch { ^ SyntaxError: Unexpected token { ` in node version 8

## Objective

Upgrade node version to 12

## References

[Cache cleanup is broken when disk based cache is used](https://github.com/screwdriver-cd/screwdriver/issues/2087)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
