### PR TITLE
fix(2087): return promise after cache directory is deleted

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -22,6 +22,6 @@ module.exports = function cacheExecutor([job, cachePath, prefix, scope, id]) {
     }
 
     return fs.remove(dir)
-        .then(() => logger.info('successfully removed directory'))
-        .catch(err => logger.error(err));
+        .then(() => Promise.resolve('successfully removed directory'))
+        .catch(err => Promise.reject(err));
 };


### PR DESCRIPTION
## Context

return Promise after cache directory is deleted

## References
[Cache cleanup is broken when disk-based cache is used](https://github.com/screwdriver-cd/screwdriver/issues/2087)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
