### PR TITLE
fix: revert cpu config to support 0.5 values

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "fs-extra": "^9.0.0",
     "path": "^0.12.7",
     "request": "^2.88.0",
-    "screwdriver-executor-k8s": "^13.16.2",
+    "screwdriver-executor-k8s": "^13.16.3",
     "screwdriver-executor-k8s-vm": "^3.2.2",
     "screwdriver-executor-router": "^1.2.0",
     "screwdriver-logger": "^1.0.0",


### PR DESCRIPTION
## Objective

Revert CPU config to support 0.5

## References

https://github.com/screwdriver-cd/executor-k8s/pull/128

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
