### PR TITLE
fix: add memory max configuration to configs

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -37,6 +37,8 @@ executor:
                     low: K8S_MEMORY_LOW
                     high: K8S_MEMORY_HIGH
                     turbo: K8S_MEMORY_TURBO
+                    # upper bound for user custom memory
+                    max: K8S_MEMORY_MAX
             # Default build timeout for all builds in this cluster
             buildTimeout: K8S_BUILD_TIMEOUT
             # Default max build timeout

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -27,7 +27,7 @@ executor:
                     low: 2
                     high: 12
                     turbo: 16
-                    # upper bound for user custom cpu
+                    # upper bound for user custom memory
                     max: 16
             # Default build timeout for all builds in this cluster
             buildTimeout: 90

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -27,6 +27,8 @@ executor:
                     low: 2
                     high: 12
                     turbo: 16
+                    # upper bound for user custom cpu
+                    max: 16
             # Default build timeout for all builds in this cluster
             buildTimeout: 90
             # Default max build timeout

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "fs-extra": "^9.0.0",
     "path": "^0.12.7",
     "request": "^2.88.0",
-    "screwdriver-executor-k8s": "^13.16.3",
+    "screwdriver-executor-k8s": "^13.16.5",
     "screwdriver-executor-k8s-vm": "^3.2.2",
     "screwdriver-executor-router": "^1.2.0",
     "screwdriver-logger": "^1.0.0",


### PR DESCRIPTION
## Objective

add max memory config to executor-k8s definition

## References

https://github.com/screwdriver-cd/executor-k8s/pull/130

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
