### PR TITLE
add k8s-sandbox executor plugins to configs

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -86,6 +86,7 @@ executor:
             retryDelay: REQUEST_RETRYDELAY
             maxAttempts: REQUEST_MAXATTEMPTS
     k8s-sandbox:
+      pluginName: k8s
       options:
         kubernetes:
             # The host or IP of the kubernetes cluster

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -85,6 +85,83 @@ executor:
             # in milliseconds
             retryDelay: REQUEST_RETRYDELAY
             maxAttempts: REQUEST_MAXATTEMPTS
+    k8s-sandbox:
+      options:
+        kubernetes:
+            # The host or IP of the kubernetes cluster
+            host: K8S_HOST
+            # Privileged mode, default restricted, set to true for trusted container runtime use-case
+            privileged: K8S_SECURITYCONTEXT_PRIVILEGED
+            # The jwt token used for authenticating kubernetes requests
+            token: K8S_TOKEN
+            jobsNamespace: K8S_JOBS_NAMESPACE
+            # Preferable to use service account instead of token secret
+            serviceAccount: K8S_SERVICE_ACCOUNT_NAME
+            automountServiceAccountToken: K8S_AUTOMOUNT_SERVICE_ACCOUNT_TOKEN
+            # feature flag to enable docker in docker
+            dockerFeatureEnabled: DOCKER_FEATURE_ENABLED
+            # Resources for build pod
+            resources:
+                # Number of cpu cores
+                cpu:
+                    micro: K8S_CPU_MICRO
+                    low: K8S_CPU_LOW
+                    high: K8S_CPU_HIGH
+                    turbo: K8S_CPU_TURBO
+                    # upper bound for user custom cpu
+                    max: K8S_CPU_MAX
+                # Memory in GB
+                memory:
+                    micro: K8S_MEMORY_MICRO
+                    low: K8S_MEMORY_LOW
+                    high: K8S_MEMORY_HIGH
+                    turbo: K8S_MEMORY_TURBO
+                    # upper bound for user custom memory
+                    max: K8S_MEMORY_MAX
+            # Default build timeout for all builds in this cluster
+            buildTimeout: K8S_BUILD_TIMEOUT
+            # Default max build timeout
+            maxBuildTimeout: K8S_MAX_BUILD_TIMEOUT
+            lifecycleHooks:
+                __name: K8S_LIFECYCLE_HOOKS
+                __format: json
+            # k8s node selectors for approprate build pod scheduling.
+            # Value is Object of format { label: 'value' } See
+            # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node
+            # Eg: { dedicated: 'screwdriver' } to schedule pods on nodes having
+            # label-value of dedicated=screwdriver
+            nodeSelectors:
+                __name: K8S_SANDBOX_NODE_SELECTORS
+                __format: json
+            # k8s preferred node selectors for build pod scheduling
+            # See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
+            preferredNodeSelectors:
+                __name: K8S_SANDBOX_PREFERRED_NODE_SELECTORS
+                __format: json
+            # k8s annotations
+            # Value is Object of format { key: 'value' } See
+            # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+            # Eg: {"io.kubernetes.cri.untrusted-workload": "true"}
+            annotations:
+                __name: K8S_ANNOTATIONS
+                __format: json
+            # support for kata-containers-as-a-runtimeclass
+            runtimeClass: K8S_RUNTIME_CLASS
+        # Launcher image to use
+        launchImage: LAUNCH_IMAGE
+        # Launcher container tag to use
+        launchVersion: LAUNCH_VERSION
+        # Prefix to the pod
+        prefix: EXECUTOR_PREFIX
+        # Circuit breaker config
+        fusebox:
+            breaker:
+                # in milliseconds
+                timeout: CIRCUIT_TIMEOUT
+        requestretry:
+            # in milliseconds
+            retryDelay: REQUEST_RETRYDELAY
+            maxAttempts: REQUEST_MAXATTEMPTS
     k8s-vm:
       weightage: WEIGHT_K8S_VM
       options:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -56,6 +56,57 @@ executor:
             # in milliseconds
             retryDelay: 3000
             maxAttempts: 5
+    k8s-sandbox:
+      pluginName: k8s
+      options:
+        kubernetes:
+            # The host or IP of the kubernetes cluster
+            host: kubernetes.default
+            # Privileged mode, default restricted, set to true for trusted container runtime use-case
+            privileged: false
+            automountServiceAccountToken: false
+            dockerFeatureEnabled: false
+            resources:
+                cpu:
+                    # Number of cpu cores
+                    micro: 1
+                    low: 2
+                    high: 6
+                    turbo: 12
+                    # upper bound for user custom cpu
+                    max: 12
+                memory:
+                    # Memory in GB
+                    micro: 1
+                    low: 2
+                    high: 12
+                    turbo: 16
+                    # upper bound for user custom memory
+                    max: 16
+            # Default build timeout for all builds in this cluster
+            buildTimeout: 90
+            # Default max build timeout
+            maxBuildTimeout: 120
+            # k8s node selectors for approprate pod scheduling
+            nodeSelectors: {}
+            preferredNodeSelectors: {}
+            annotations: {}
+            # support for kata-containers-as-a-runtimeclass
+            runtimeClass: ""
+        # Launcher image to use
+        launchImage: screwdrivercd/launcher
+        # Container tags to use
+        launchVersion: stable
+        # Circuit breaker config
+        fusebox:
+            breaker:
+                # in milliseconds
+                timeout: 10000
+        # requestretry configs
+        requestretry:
+            # in milliseconds
+            retryDelay: 3000
+            maxAttempts: 5
     k8s-vm:
       pluginName: k8s-vm
       weightage: 0


### PR DESCRIPTION
## Context

Enable multiple configs of same executor. add k8s-sandbox executor plugin to config. 

## Objective

Helps to test production build in production cluster. Test builds are routed using nodeSelectors (K8S_SANDBOX_NODE_SELECTORS) annotation.

## References

[buildcluster-queue-worker/pull/76](https://github.com/screwdriver-cd/buildcluster-queue-worker/pull/76)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
