### PR TITLE
fix: add dnsPolicy env variable

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -20,6 +20,8 @@ executor:
             jobsNamespace: K8S_JOBS_NAMESPACE
             # Preferable to use service account instead of token secret
             serviceAccount: K8S_SERVICE_ACCOUNT_NAME
+            # Build pod DNS policy https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+            dnsPolicy: K8S_POD_DNS_POLICY
             automountServiceAccountToken: K8S_AUTOMOUNT_SERVICE_ACCOUNT_TOKEN
             # feature flag to enable docker in docker
             dockerFeatureEnabled: DOCKER_FEATURE_ENABLED

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -15,6 +15,7 @@ executor:
             privileged: false
             automountServiceAccountToken: false
             dockerFeatureEnabled: false
+            dnsPolicy: ClusterFirst
             resources:
                 cpu:
                     # Number of cpu cores


### PR DESCRIPTION
## Context

This config will allow cluster admins to set build pod DNS policy.


## References

https://github.com/screwdriver-cd/executor-k8s/pull/133

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
