### PR TITLE
fix: add config to delay pod status pending retry strategy query

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -76,6 +76,8 @@ executor:
             volumeMounts:
               __name: K8S_VOLUME_MOUNTS
               __format: json
+            # Number of milliseconds to wait before calling k8s pod query status for pending retry strategy
+            podStatusQueryDelay: K8S_POD_STATUSQUERY_DELAY
         # Launcher image to use
         launchImage: LAUNCH_IMAGE
         # Launcher container tag to use
@@ -158,6 +160,8 @@ executor:
             volumeMounts:
                 __name: K8S_VOLUME_MOUNTS
                 __format: json
+            # Number of milliseconds to wait before calling k8s pod query status for pending retry strategy
+            podStatusQueryDelay: K8S_POD_STATUSQUERY_DELAY
         # Launcher image to use
         launchImage: LAUNCH_IMAGE
         # Launcher container tag to use

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -45,6 +45,8 @@ executor:
             runtimeClass: ""
             # mount host devices
             volumeMounts: {}
+            # Number of milliseconds to wait before calling k8s pod query status for pending retry strategy
+            podStatusQueryDelay: 0
         # Launcher image to use
         launchImage: screwdrivercd/launcher
         # Container tags to use
@@ -98,7 +100,9 @@ executor:
             runtimeClass: ""
             # mount host devices
             volumeMounts: {}
-        # Launcher image to use
+            # Number of milliseconds to wait before calling k8s pod query status for pending retry strategy
+            podStatusQueryDelay: 0
+          # Launcher image to use
         launchImage: screwdrivercd/launcher
         # Container tags to use
         launchVersion: stable

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "fs-extra": "^9.0.0",
     "path": "^0.12.7",
     "request": "^2.88.0",
-    "screwdriver-executor-k8s": "^14.0.7",
+    "screwdriver-executor-k8s": "^14.0.8",
     "screwdriver-executor-k8s-vm": "^4.0.0",
     "screwdriver-executor-router": "^2.0.0",
     "screwdriver-logger": "^1.0.0",


### PR DESCRIPTION
## Objective

Add config option to delay pod status pending retry strategy query. 

## References

https://github.com/screwdriver-cd/executor-k8s/pull/138
https://github.com/screwdriver-cd/executor-k8s/pull/139
https://github.com/screwdriver-cd/executor-k8s/pull/140
https://github.com/screwdriver-cd/executor-k8s/pull/141

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
