### PR TITLE
feat(2265): Allow custom podLabels [1]

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -52,7 +52,12 @@ executor:
             lifecycleHooks:
               __name: K8S_LIFECYCLE_HOOKS
               __format: json
-            # k8s node selectors for approprate build pod scheduling.
+            # k8s pod labels for cluster settings
+            # eg: { network-egress: 'restricted' } to execute builds where public internet access is blocked by default
+            podLabels:
+              __name: K8S_POD_LABELS
+              __format: json
+            # k8s node selectors for appropriate build pod scheduling.
             # Value is Object of format { label: 'value' } See
             # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node
             # Eg: { dedicated: 'screwdriver' } to schedule pods on nodes having
@@ -138,7 +143,12 @@ executor:
             lifecycleHooks:
                 __name: K8S_LIFECYCLE_HOOKS
                 __format: json
-            # k8s node selectors for approprate build pod scheduling.
+            # k8s pod labels for cluster settings
+            # eg: { network-egress: 'restricted' } to execute builds where public internet access is blocked by default
+            podLabels:
+              __name: K8S_POD_LABELS
+              __format: json
+            # k8s node selectors for appropriate build pod scheduling.
             # Value is Object of format { label: 'value' } See
             # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node
             # Eg: { dedicated: 'screwdriver' } to schedule pods on nodes having
@@ -221,7 +231,12 @@ executor:
             maxBuildTimeout: K8S_VM_MAX_BUILD_TIMEOUT
             # Termination Grace period:
             terminationGracePeriodSeconds: TERMINATION_GRACE_PERIOD_SECONDS
-            # k8s node selectors for approprate build pod scheduling.
+            # k8s pod labels for cluster settings
+            # eg: { network-egress: 'restricted' } to execute builds where public internet access is blocked by default
+            podLabels:
+              __name: K8S_POD_LABELS
+              __format: json
+            # k8s node selectors for appropriate build pod scheduling.
             # Value is Object of format { label: 'value' } See
             # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node
             # Eg: { dedicated: 'screwdriver' } to schedule pods on nodes having

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -81,6 +81,9 @@ executor:
               __format: json
             # support for kata-containers-as-a-runtimeclass
             runtimeClass: K8S_RUNTIME_CLASS
+            # image pull secret name
+            # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
+            imagePullSecretName: K8S_IMAGE_PULL_SECRET_NAME
             # mount host devices
             volumeMounts:
               __name: K8S_VOLUME_MOUNTS
@@ -172,6 +175,9 @@ executor:
                 __format: json
             # support for kata-containers-as-a-runtimeclass
             runtimeClass: K8S_RUNTIME_CLASS
+            # image pull secret name
+            # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
+            imagePullSecretName: K8S_IMAGE_PULL_SECRET_NAME
             # mount host devices
             volumeMounts:
                 __name: K8S_VOLUME_MOUNTS

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -22,6 +22,8 @@ executor:
             serviceAccount: K8S_SERVICE_ACCOUNT_NAME
             # Build pod DNS policy https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
             dnsPolicy: K8S_POD_DNS_POLICY
+            # Build pod Image Pull policy https://kubernetes.io/docs/concepts/containers/images/#updating-images
+            imagePullPolicy: K8S_POD_IMAGE_PULL_POLICY
             automountServiceAccountToken: K8S_AUTOMOUNT_SERVICE_ACCOUNT_TOKEN
             # feature flag to enable docker in docker
             dockerFeatureEnabled: DOCKER_FEATURE_ENABLED

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -16,6 +16,7 @@ executor:
             automountServiceAccountToken: false
             dockerFeatureEnabled: false
             dnsPolicy: ClusterFirst
+            imagePullPolicy: Always
             resources:
                 cpu:
                     # Number of cpu cores

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -37,7 +37,9 @@ executor:
             buildTimeout: 90
             # Default max build timeout
             maxBuildTimeout: 120
-            # k8s node selectors for approprate pod scheduling
+            # k8s pod labels for cluster settings
+            podLabels: {}
+            # k8s node selectors for appropriate pod scheduling
             nodeSelectors: {}
             preferredNodeSelectors: {}
             annotations: {}
@@ -92,7 +94,9 @@ executor:
             buildTimeout: 90
             # Default max build timeout
             maxBuildTimeout: 120
-            # k8s node selectors for approprate pod scheduling
+            # k8s pod labels for cluster settings
+            podLabels: {}
+            # k8s node selectors for appropriate pod scheduling
             nodeSelectors: {}
             preferredNodeSelectors: {}
             annotations: {}
@@ -148,7 +152,9 @@ executor:
             buildTimeout: 90
             # Default max build timeout
             maxBuildTimeout: 120
-            # k8s node selectors for approprate pod scheduling
+            # k8s pod labels for cluster settings
+            podLabels: {}
+            # k8s node selectors for appropriate pod scheduling
             nodeSelectors: {}
             preferredNodeSelectors: {}
         # Launcher image to use

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -46,6 +46,9 @@ executor:
             annotations: {}
             # support for kata-containers-as-a-runtimeclass
             runtimeClass: ""
+            # image pull secret name
+            # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
+            imagePullSecretName: ""
             # mount host devices
             volumeMounts: {}
             # Number of milliseconds to wait before calling k8s pod query status for pending retry strategy
@@ -103,6 +106,9 @@ executor:
             annotations: {}
             # support for kata-containers-as-a-runtimeclass
             runtimeClass: ""
+            # image pull secret name
+            # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
+            imagePullSecretName: ""
             # mount host devices
             volumeMounts: {}
             # Number of milliseconds to wait before calling k8s pod query status for pending retry strategy

--- a/test/data/executorConfig.json
+++ b/test/data/executorConfig.json
@@ -23,6 +23,7 @@
                 },
                 "buildTimeout": 90,
                 "maxBuildTimeout": 120,
+                "podLabels": {},
                 "nodeSelectors": {},
                 "preferredNodeSelectors": {},
                 "annotations": {},
@@ -64,6 +65,7 @@
                 },
                 "buildTimeout": 90,
                 "maxBuildTimeout": 120,
+                "podLabels": {},
                 "nodeSelectors": {},
                 "preferredNodeSelectors": {}
             },

--- a/test/data/executorConfig.json
+++ b/test/data/executorConfig.json
@@ -27,7 +27,8 @@
                 "nodeSelectors": {},
                 "preferredNodeSelectors": {},
                 "annotations": {},
-                "runtimeClass": ""
+                "runtimeClass": "",
+                "imagePullSecretName": ""
             },
             "launchImage": "screwdrivercd/launcher",
             "launchVersion": "stable",

--- a/test/data/executorConfigWeightage.json
+++ b/test/data/executorConfigWeightage.json
@@ -24,6 +24,7 @@
                 },
                 "buildTimeout": 90,
                 "maxBuildTimeout": 120,
+                "podLabels": {},
                 "nodeSelectors": {},
                 "preferredNodeSelectors": {},
                 "annotations": {},
@@ -66,6 +67,7 @@
                 },
                 "buildTimeout": 90,
                 "maxBuildTimeout": 120,
+                "podLabels": {},
                 "nodeSelectors": {},
                 "preferredNodeSelectors": {}
             },

--- a/test/data/executorConfigWeightage.json
+++ b/test/data/executorConfigWeightage.json
@@ -28,7 +28,8 @@
                 "nodeSelectors": {},
                 "preferredNodeSelectors": {},
                 "annotations": {},
-                "runtimeClass": ""
+                "runtimeClass": "",
+                "imagePullSecretName": ""
             },
             "launchImage": "screwdrivercd/launcher",
             "launchVersion": "stable",


### PR DESCRIPTION
## Context

Cluster admins might want to set custom pod labels.

## Objective

This PR adds config:
- to allow for custom pod labels
- to set imagePullPolicy
- to configure imagePullSecrets name

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2265

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
