### PR TITLE
feat: update pkg versions and config

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -47,6 +47,8 @@ executor:
             buildTimeout: K8S_BUILD_TIMEOUT
             # Default max build timeout
             maxBuildTimeout: K8S_MAX_BUILD_TIMEOUT
+            # Termination Grace period:
+            terminationGracePeriodSeconds: TERMINATION_GRACE_PERIOD_SECONDS
             lifecycleHooks:
               __name: K8S_LIFECYCLE_HOOKS
               __format: json
@@ -131,6 +133,8 @@ executor:
             buildTimeout: K8S_BUILD_TIMEOUT
             # Default max build timeout
             maxBuildTimeout: K8S_MAX_BUILD_TIMEOUT
+            # Termination Grace period:
+            terminationGracePeriodSeconds: TERMINATION_GRACE_PERIOD_SECONDS
             lifecycleHooks:
                 __name: K8S_LIFECYCLE_HOOKS
                 __format: json
@@ -215,6 +219,8 @@ executor:
             buildTimeout: K8S_VM_BUILD_TIMEOUT
             # Default max build timeout
             maxBuildTimeout: K8S_VM_MAX_BUILD_TIMEOUT
+            # Termination Grace period:
+            terminationGracePeriodSeconds: TERMINATION_GRACE_PERIOD_SECONDS
             # k8s node selectors for approprate build pod scheduling.
             # Value is Object of format { label: 'value' } See
             # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -37,6 +37,8 @@ executor:
             buildTimeout: 90
             # Default max build timeout
             maxBuildTimeout: 120
+            # Termination Grace period defaulted to 60 seconds
+            terminationGracePeriodSeconds: 60
             # k8s node selectors for approprate pod scheduling
             nodeSelectors: {}
             preferredNodeSelectors: {}
@@ -92,6 +94,8 @@ executor:
             buildTimeout: 90
             # Default max build timeout
             maxBuildTimeout: 120
+            # Termination Grace period defaulted to 60 seconds
+            terminationGracePeriodSeconds: 60
             # k8s node selectors for approprate pod scheduling
             nodeSelectors: {}
             preferredNodeSelectors: {}
@@ -149,6 +153,8 @@ executor:
             # Default max build timeout
             maxBuildTimeout: 120
             # k8s node selectors for approprate pod scheduling
+            # Termination Grace period defaulted to 60 seconds
+            terminationGracePeriodSeconds: 60
             nodeSelectors: {}
             preferredNodeSelectors: {}
         # Launcher image to use

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "fs-extra": "^9.0.0",
     "path": "^0.12.7",
     "request": "^2.88.0",
-    "screwdriver-executor-k8s": "^14.1.0",
-    "screwdriver-executor-k8s-vm": "^4.1.0",
+    "screwdriver-executor-k8s": "^14.3.1",
+    "screwdriver-executor-k8s-vm": "^4.3.0",
     "screwdriver-executor-router": "^2.0.0",
     "screwdriver-logger": "^1.0.0",
     "threads": "^0.12.1"

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "fs-extra": "^9.0.0",
     "path": "^0.12.7",
     "request": "^2.88.0",
-    "screwdriver-executor-k8s": "^14.0.8",
-    "screwdriver-executor-k8s-vm": "^4.0.0",
+    "screwdriver-executor-k8s": "^14.1.0",
+    "screwdriver-executor-k8s-vm": "^4.1.0",
     "screwdriver-executor-router": "^2.0.0",
     "screwdriver-logger": "^1.0.0",
     "threads": "^0.12.1"


### PR DESCRIPTION
## Context

Add new env var to control the termination grace period for pods

## Objective

This PR adds a new env var option configurable via worker

## References

https://github.com/screwdriver-cd/screwdriver/issues/1125

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
