### PR TITLE
fix: rabbitmq config

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -227,12 +227,12 @@ rabbitmq:
     # Virtual Host for queues
     vhost: /screwdriver
     # Connect Options
-    connectOptions: { json: true, heartbeatIntervalInSeconds: 20, reconnectTimeInSeconds: 30 }
+    connectOptions: '{ "json": true, "heartbeatIntervalInSeconds": 20, "reconnectTimeInSeconds": 30 }'
     # Queue name to consume from
     queue: test
     # Prefetch count
     prefetchCount: "20"
     # Queue options
-    queueOptions: { durable: true, autodelete: false, deadLetterExchange: 'build', deadLetterRoutingKey: 'test_retry' }
+    queueOptions: '{ "durable": true, "autodelete": false, "deadLetterExchange": "build", "deadLetterRoutingKey": "test_retry" }'
     # Message reprocess limit - max retry for a message
     messageReprocessLimit: "3"

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,9 +19,9 @@ function getConfig() {
     return {
         amqpURI,
         host,
-        connectOptions,
+        connectOptions: JSON.parse(connectOptions),
         queue,
-        queueOptions,
+        queueOptions: JSON.parse(queueOptions),
         prefetchCount: Number(prefetchCount),
         messageReprocessLimit: Number(messageReprocessLimit),
         cacheStrategy: strategy,

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,17 +1,13 @@
 'use strict';
 
 const assert = require('chai').assert;
-const mockery = require('mockery');
-const sinon = require('sinon');
-
-sinon.assert.expose(assert, { prefix: '' });
 
 describe('config test', () => {
     const configDef = {
         ecosystem: {
             cache: {
-                strategy: 'disk',
-                path: '/persistent_cache'
+                strategy: 's3',
+                path: '/'
             }
         },
         rabbitmq: {
@@ -38,24 +34,9 @@ describe('config test', () => {
         }
     };
 
-    let configMock;
     let config;
 
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
-
     beforeEach(() => {
-        configMock = {
-            get: sinon.stub()
-        };
-
-        mockery.registerMock('config', configMock);
-        configMock.get.withArgs('rabbitmq').returns(configDef.rabbitmq);
-        configMock.get.withArgs('ecosystem').returns(configDef.ecosystem);
         // eslint-disable-next-line global-require
         config = require('../lib/config');
     });
@@ -72,14 +53,5 @@ describe('config test', () => {
             cacheStrategy: configDef.ecosystem.cache.strategy,
             cachePath: configDef.ecosystem.cache.path
         });
-    });
-
-    afterEach(() => {
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
     });
 });


### PR DESCRIPTION
## Context
Setting `connectOptions` or `queueOptions` using Kubernetes env was not correctly set. Only strings are allowed in Kubernetes env.
Also, there was a problem in the test code where mock always returned the value defined in `configDef`, so the test always succeeded.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- Fix it so that the values set to `connectOptions` or `queueOptions` are properties of the object.
- Remove `getConfig` mock 
  - Compare the value set in `config/default` with the value defined in `confDef`

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvar-v1-core
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
