### PR TITLE
fix (2303): remove unused queueOptions config

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -342,8 +342,6 @@ rabbitmq:
     connectOptions: RABBITMQ_CONNECT_OPTIONS
     # Queue name to consume from
     queue: RABBITMQ_QUEUE
-    # Queue options
-    queueOptions: RABBITMQ_QUEUE_OPTIONS
     # Prefetch count
     prefetchCount: RABBITMQ_PREFETCH_COUNT
     # Message reprocess limit

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -232,7 +232,5 @@ rabbitmq:
     queue: test
     # Prefetch count
     prefetchCount: "20"
-    # Queue options
-    queueOptions: '{ "durable": true, "autodelete": false, "deadLetterExchange": "build", "deadLetterRoutingKey": "test_retry" }'
     # Message reprocess limit - max retry for a message
     messageReprocessLimit: "3"

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ const helper = require('./lib/helper');
 const config = require('./lib/config');
 const logger = require('screwdriver-logger');
 const { amqpURI, host, connectOptions,
-    queue, queueOptions, prefetchCount,
-    messageReprocessLimit, cacheStrategy, cachePath } = config.getConfig();
+    queue, prefetchCount, messageReprocessLimit,
+    cacheStrategy, cachePath } = config.getConfig();
 const spawn = threads.spawn;
 const CACHE_STRATEGY_DISK = 'disk';
 let channelWrapper;
@@ -142,7 +142,7 @@ connection.on('disconnect', (params) => {
 channelWrapper = connection.createChannel({
     setup(channel) {
         return Promise.all([
-            channel.checkQueue(queue, queueOptions),
+            channel.checkQueue(queue),
             channel.prefetch(prefetchCount),
             channel.consume(queue, onMessage)
         ]);

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,8 +6,7 @@ const rabbitmqConfig = config.get('rabbitmq');
 const ecosystemConfig = config.get('ecosystem');
 const { strategy, path } = ecosystemConfig.cache;
 const { protocol, username, password, host, port, vhost, connectOptions,
-    queue, queueOptions, prefetchCount,
-    messageReprocessLimit } = rabbitmqConfig;
+    queue, prefetchCount, messageReprocessLimit } = rabbitmqConfig;
 const amqpURI = `${protocol}://${username}:${password}@${host}:${port}${vhost}`;
 
 /**
@@ -21,7 +20,6 @@ function getConfig() {
         host,
         connectOptions: JSON.parse(connectOptions),
         queue,
-        queueOptions: JSON.parse(queueOptions),
         prefetchCount: Number(prefetchCount),
         messageReprocessLimit: Number(messageReprocessLimit),
         cacheStrategy: strategy,

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -23,12 +23,6 @@ describe('config test', () => {
                 reconnectTimeInSeconds: 30
             },
             queue: 'test',
-            queueOptions: {
-                durable: true,
-                autodelete: false,
-                deadLetterExchange: 'build',
-                deadLetterRoutingKey: 'test_retry'
-            },
             prefetchCount: 20,
             messageReprocessLimit: 3
         }
@@ -47,7 +41,6 @@ describe('config test', () => {
             host: configDef.rabbitmq.host,
             connectOptions: configDef.rabbitmq.connectOptions,
             queue: configDef.rabbitmq.queue,
-            queueOptions: configDef.rabbitmq.queueOptions,
             prefetchCount: configDef.rabbitmq.prefetchCount,
             messageReprocessLimit: configDef.rabbitmq.messageReprocessLimit,
             cacheStrategy: configDef.ecosystem.cache.strategy,


### PR DESCRIPTION
## Context

Rabbitmq queue options configuration is defined but not used. 

## Objective

Remove unused queue options configuration. checkQueue will only validate the queue name and not options. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/2303

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
