### PR TITLE
fix: update Dockerfile not to create package-lock.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Install Screwdriver build cluster queue worker
-RUN npm install screwdriver-buildcluster-queue-worker@$VERSION
+RUN npm install screwdriver-buildcluster-queue-worker@$VERSION --no-package-lock
 WORKDIR /usr/src/app/node_modules/screwdriver-buildcluster-queue-worker
 
 # Run the service


### PR DESCRIPTION
## Context
I found useless `package-lock.json`

```
root@806c4d313601:/usr/src/app# ls -lh
total 88K
drwxr-xr-x 1 root root 4.0K Jan 22 12:23 node_modules
-rw-r--r-- 1 root root  80K Dec  8 17:25 package-lock.json
```


<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
not to create package-lock.json

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
- https://docs.npmjs.com/cli/v6/commands/npm-install
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
