### PR TITLE
feat: revert dlc env vars

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -27,10 +27,6 @@ executor:
             automountServiceAccountToken: K8S_AUTOMOUNT_SERVICE_ACCOUNT_TOKEN
             # feature flag to enable docker in docker
             dockerFeatureEnabled: DOCKER_FEATURE_ENABLED
-            # feature flag and path for using docker layer cache
-            dlcEnabled: DOCKER_LAYER_CACHE_ENABLED
-            dlcPath: DOCKER_LAYER_CACHE_PATH
-            dlcMountPath: DOCKER_LAYER_CACHE_MOUNT_PATH
             # Resources for build pod
             resources:
                 # Number of cpu cores

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -15,9 +15,6 @@ executor:
             privileged: false
             automountServiceAccountToken: false
             dockerFeatureEnabled: false
-            dlcEnabled: false
-            dlcPath: /
-            dlcMountPath: /var/lib/docker
             dnsPolicy: ClusterFirst
             imagePullPolicy: Always
             resources:


### PR DESCRIPTION
## Context

DLC with mounting cache drive is slow with docker builds as it read writes from network drive so we cannot use this approach

## Objective

This PR removes env vars related to dlc

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
