### PR TITLE
fix(2343): Add liveness endpoint

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -347,6 +347,9 @@ rabbitmq:
     # Message reprocess limit
     messageReprocessLimit: RABBITMQ_MSG_REPROCESS_LIMIT
 httpd:
+  # Port to listen on
   port: PORT
+  # Host to listen on (set to 0.0.0.0 to accept all connections)
   host: HOST
+  # Externally routable URI (usually your load balancer or CNAME)
   uri: URI

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -346,3 +346,7 @@ rabbitmq:
     prefetchCount: RABBITMQ_PREFETCH_COUNT
     # Message reprocess limit
     messageReprocessLimit: RABBITMQ_MSG_REPROCESS_LIMIT
+httpd:
+  port: PORT
+  host: HOST
+  uri: URI

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -234,3 +234,7 @@ rabbitmq:
     prefetchCount: "20"
     # Message reprocess limit - max retry for a message
     messageReprocessLimit: "3"
+httpd:
+    port: 80
+    host: 0.0.0.0
+    uri: http://IP_ADDRESS:PORT

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -235,6 +235,9 @@ rabbitmq:
     # Message reprocess limit - max retry for a message
     messageReprocessLimit: "3"
 httpd:
+    # Port to listen on
     port: 80
+    # Host to listen on (set to localhost to only accept connections from this machine)
     host: 0.0.0.0
+    # Externally routable URI (usually your load balancer or CNAME)
     uri: http://IP_ADDRESS:PORT

--- a/index.js
+++ b/index.js
@@ -104,17 +104,17 @@ const onMessage = (data) => {
                             `${error}`,
                             (err, response) => {
                                 if (err) {
-                                // eslint-disable-next-line max-len
+                                    // eslint-disable-next-line max-len
                                     logger.error(`failed to update build status for build ${buildConfig.buildId}: ${err} ${JSON.stringify(response)}`);
                                 } else {
-                                // eslint-disable-next-line max-len
+                                    // eslint-disable-next-line max-len
                                     logger.info(`build status successfully updated for build ${buildConfig.buildId}`);
                                 }
                             });
                         channelWrapper.ack(data);
                     } else {
                         logger.info(`err: ${error}, don't acknowledge, ` +
-                        `retried ${retryCount}(${messageReprocessLimit}) for ${job}`);
+                            `retried ${retryCount}(${messageReprocessLimit}) for ${job}`);
                         channelWrapper.nack(data, false, false);
                     }
                     thread.kill();
@@ -136,7 +136,7 @@ connection.on('connect',
 
 connection.on('disconnect', (params) => {
     logger.info(`server disconnected: ${params.err.stack}. ` +
-      `reconnecting rabbitmq server ${host}`);
+        `reconnecting rabbitmq server ${host}`);
 });
 
 channelWrapper = connection.createChannel({
@@ -153,3 +153,11 @@ channelWrapper.waitForConnect()
     .then(() => {
         logger.info(`waiting for messages in queue: ${queue}`);
     });
+
+const conf = require('config');
+const server = require('./lib/server');
+
+// Setup HTTPd
+const httpdConfig = conf.get('httpd');
+
+server(httpdConfig, connection);

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const Hapi = require('@hapi/hapi');
+const logger = require('screwdriver-logger');
+
+module.exports = async (config, amqpConnection) => {
+    try {
+        const server = new Hapi.Server({
+            port: config.port,
+            host: config.host,
+            uri: config.uri,
+            routes: {
+                log: { collect: true }
+            },
+            router: {
+                stripTrailingSlash: true
+            }
+        });
+
+        server.route([
+            {
+                method: 'GET',
+                path: '/status',
+                handler(request, h) {
+                    return h.response('ok').code(200);
+                }
+            },
+            {
+                method: 'GET',
+                path: '/health',
+                handler(request, h) {
+                    if (amqpConnection.isConnected()) {
+                        return h.response('ok').code(200);
+                    }
+
+                    return h.response('unavailable').code(503);
+                }
+            }
+        ]);
+
+        await server.start();
+        logger.info('Server running on %s', server.info.uri);
+
+        return server;
+    } catch (err) {
+        logger.error(`Error in starting server ${err}`);
+        throw err;
+    }
+};
+
+process.on('unhandledRejection', (err) => {
+    logger.error('Unhandled error', err);
+    process.exit(1);
+});

--- a/lib/server.js
+++ b/lib/server.js
@@ -20,14 +20,12 @@ module.exports = async (config, amqpConnection) => {
         server.route([
             {
                 method: 'GET',
-                path: '/status',
-                handler(request, h) {
-                    return h.response('ok').code(200);
-                }
-            },
-            {
-                method: 'GET',
                 path: '/health',
+                config: {
+                    description: 'RabbitMQ connection status',
+                    notes: 'Should respond with 200: ok',
+                    tags: ['api']
+                },
                 handler(request, h) {
                     if (amqpConnection.isConnected()) {
                         return h.response('ok').code(200);

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "sinon": "^7.2.5"
   },
   "dependencies": {
+    "@hapi/hapi": "^20.1.0",
     "amqp-connection-manager": "^3.2.0",
     "amqplib": "^0.5.6",
     "config": "^2.0.1",
@@ -53,7 +54,7 @@
     "screwdriver-executor-k8s": "^14.3.3",
     "screwdriver-executor-k8s-vm": "^4.3.0",
     "screwdriver-executor-router": "^2.0.0",
-    "screwdriver-logger": "^1.0.0",
+    "screwdriver-logger": "^1.0.2",
     "threads": "^0.12.1"
   },
   "release": {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const assert = require('chai').assert;
+const init = require('../lib/server');
+
+const serverConfig = {
+    port: 80,
+    host: '0.0.0.0'
+};
+
+describe('GET /status', () => {
+    let server;
+    const requestParam = {
+        method: 'get',
+        url: '/status'
+    };
+
+    beforeEach(async () => {
+        server = await init(serverConfig);
+    });
+
+    afterEach(async () => {
+        await server.stop();
+    });
+
+    it('responds with 200', async () => {
+        const res = await server.inject(requestParam);
+
+        assert.equal(res.statusCode, 200);
+    });
+});
+
+describe('GET /health', () => {
+    let server;
+    const requestParam = {
+        method: 'get',
+        url: '/health'
+    };
+
+    class AmqpConnectionMock {
+        constructor(status) {
+            this.status = status;
+        }
+
+        isConnected() {
+            return this.status;
+        }
+    }
+
+    afterEach(async () => {
+        await server.stop();
+    });
+
+    it('responds with 200', async () => {
+        const amqpConnection = new AmqpConnectionMock(true);
+
+        server = await init(serverConfig, amqpConnection);
+        const res = await server.inject(requestParam);
+
+        assert.equal(res.statusCode, 200);
+    });
+
+    it('responds with 503', async () => {
+        const amqpConnection = new AmqpConnectionMock(false);
+
+        server = await init(serverConfig, amqpConnection);
+        const res = await server.inject(requestParam);
+
+        assert.equal(res.statusCode, 503);
+    });
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -8,28 +8,6 @@ const serverConfig = {
     host: '0.0.0.0'
 };
 
-describe('GET /status', () => {
-    let server;
-    const requestParam = {
-        method: 'get',
-        url: '/status'
-    };
-
-    beforeEach(async () => {
-        server = await init(serverConfig);
-    });
-
-    afterEach(async () => {
-        await server.stop();
-    });
-
-    it('responds with 200', async () => {
-        const res = await server.inject(requestParam);
-
-        assert.equal(res.statusCode, 200);
-    });
-});
-
 describe('GET /health', () => {
     let server;
     const requestParam = {


### PR DESCRIPTION
## Context
In buildcluster-queue-worker, there was no endpoint that could be monitored using liveness.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Add liveness(`/health`) endpoint.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
Issue: https://github.com/screwdriver-cd/screwdriver/issues/2343
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
