### PR TITLE
feat: fix retry msg config

### DIFF
--- a/receiver.js
+++ b/receiver.js
@@ -144,8 +144,8 @@ const onMessage = (data) => {
  */
 const onRetryMessage = async (data) => {
     try {
-        const buildConfig = JSON.parse(data.content);
-        const jobType = buildConfig.job;
+        const parsedData = JSON.parse(data.content);
+        const { jobType, buildConfig } = parsedData;
         const thread = spawn('./lib/jobs.js');
         let retryCount = 0;
         const { buildId } = buildConfig;


### PR DESCRIPTION
## Context

onRetryMessage fn was reading the incorrect config

## Objective

This PR fixes reading config in onRetrymessage fn

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
