### PR TITLE
feat: requeue verify jobs instead of deadlettering

### DIFF
--- a/receiver.js
+++ b/receiver.js
@@ -176,7 +176,7 @@ const onRetryMessage = async (data) => {
                 } else {
                     logger.info(`err: ${error}, don't acknowledge, retried ` +
                         `${retryCount}(${messageReprocessLimit}) for ${job}`);
-                    channelWrapper.nack(data, false, false);
+                    channelWrapper.nack(data, false, true); // requeue it instead of deadlettering
                 }
                 thread.kill();
             })


### PR DESCRIPTION
## Context

Worker should requeue verify jobs on nack instead of dead lettering them as we want to check the status for all retry builds and either mark them FAILURE or acknowledge

## Objective

This PR re-queues verify jobs instead of dead lettering on a negative acknowledgment

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
