### PR TITLE
fix: add missing thread kill which backs up memory

### DIFF
--- a/receiver.js
+++ b/receiver.js
@@ -187,6 +187,7 @@ const onRetryMessage = async data => {
                     }
                 }
                 channelWrapper.ack(data);
+                thread.kill();
             })
             .on('error', async error => {
                 if (retryCount >= messageReprocessLimit) {


### PR DESCRIPTION
## Context

Worker spawns a thread for each message which need to be cleaned else will clog the memory

## Objective

This PR adds the missing `thread.kill` to clean up any process that was completed.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
