### PR TITLE
feat: fix default for retry queue

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -239,7 +239,7 @@ rabbitmq:
     # Queue name of the retry queue
     retryQueue: sdRetryQueue
     # retry queue enable/disable flag
-    retryQueueEnabled: true
+    retryQueueEnabled: false
     # Exchange / router name for rabbitmq
     exchange: build
 httpd:

--- a/lib/config.js
+++ b/lib/config.js
@@ -24,6 +24,24 @@ const {
 const amqpURI = `${protocol}://${username}:${password}@${host}:${port}${vhost}`;
 
 /**
+ * convert value to Boolean
+ * @method convertToBool
+ * @param {(Boolean|String)} value
+ * @return {Boolean}
+ */
+function convertToBool(value) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    // trueList refers to https://yaml.org/type/bool.html
+    const trueList = ['on', 'true', 'yes', 'y'];
+    const lowerValue = String(value).toLowerCase();
+
+    return trueList.includes(lowerValue);
+}
+
+/**
  * get configurations to connect to rabbitmq server, cache strategy and cache path
  * @method getConfig
  * @return {Object}
@@ -39,7 +57,7 @@ function getConfig() {
         cacheStrategy: strategy,
         cachePath: path,
         retryQueue,
-        retryQueueEnabled,
+        retryQueueEnabled: convertToBool(retryQueueEnabled),
         exchange
     };
 }

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -26,7 +26,7 @@ describe('config test', () => {
             prefetchCount: 20,
             messageReprocessLimit: 3,
             retryQueue: 'sdRetryQueue',
-            retryQueueEnabled: true,
+            retryQueueEnabled: false,
             exchange: 'build'
         }
     };

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -7,7 +7,7 @@ const sinon = require('sinon');
 
 sinon.assert.expose(chai.assert, { prefix: '' });
 
-describe('rabbitmq message consumer test', async () => {
+describe('rabbitmq message consumer', async () => {
     let requestMock;
     let helperMock;
     let retryQMock;
@@ -42,83 +42,138 @@ describe('rabbitmq message consumer test', async () => {
         }
     };
 
+    class AmqpConnectionMock {
+        connect() {
+            return {
+                on: sinon.stub().resolves(),
+                createChannel: sinon.stub().returns({
+                    publish: sinon.stub().resolves(),
+                    waitForConnect: sinon.stub().resolves()
+                })
+            };
+        }
+    }
+
     before(() => {
         mockery.enable({
             useCleanCache: true,
             warnOnUnregistered: false
         });
     });
-
-    beforeEach(async () => {
-        retryQMock = {
-            push: sinon.stub()
-        };
-
-        configMock = {
-            getConfig: () => configObj
-        };
-
-        class AmqpConnectionMock {
-            connect() {
-                return {
-                    on: sinon.stub().resolves(),
-                    createChannel: sinon.stub().returns({
-                        publish: sinon.stub().resolves(),
-                        waitForConnect: sinon.stub().resolves()
-                    })
-                };
-            }
-        }
-        ampqConnMock = new AmqpConnectionMock();
-        requestMock = sinon.stub();
-
-        mockery.registerMock('./lib/config', configMock);
-        mockery.registerMock('request', requestMock);
-        mockery.registerMock('amqp-connection-manager', ampqConnMock);
-        mockery.registerMock('./lib/helper', helperMock);
-        mockery.registerMock('./lib/retry-queue', retryQMock);
-
-        /* eslint-disable global-require */
-        const receiver = require('../receiver');
-
-        connection = await receiver.listen();
-    });
-
-    afterEach(() => {
-        mockery.deregisterAll();
-        mockery.resetCache();
-        process.removeAllListeners('SIGTERM');
-        connection = null;
-    });
-
     after(() => {
         mockery.disable();
     });
+    describe('rabbitmq message consumer test', async () => {
+        beforeEach(async () => {
+            retryQMock = {
+                push: sinon.stub()
+            };
+            configMock = {
+                getConfig: () => configObj
+            };
+            ampqConnMock = new AmqpConnectionMock();
+            requestMock = sinon.stub();
 
-    it('creates a rabbitmq connection', async () => {
-        try {
-            assert.calledTwice(connection.on);
-            assert.notEqual(connection.createChannel, null);
-        } catch (error) {
-            throw new Error('should not fail');
-        }
+            mockery.registerMock('./lib/config', configMock);
+            mockery.registerMock('request', requestMock);
+            mockery.registerMock('amqp-connection-manager', ampqConnMock);
+            mockery.registerMock('./lib/helper', helperMock);
+            mockery.registerMock('./lib/retry-queue', retryQMock);
+
+            /* eslint-disable global-require */
+            const receiver = require('../receiver');
+
+            connection = await receiver.listen();
+        });
+
+        afterEach(() => {
+            mockery.deregisterAll();
+            mockery.resetCache();
+            process.removeAllListeners('SIGTERM');
+            connection = null;
+        });
+        it('creates a rabbitmq connection', async () => {
+            try {
+                assert.calledTwice(connection.on);
+                assert.notEqual(connection.createChannel, null);
+            } catch (error) {
+                throw new Error('should not fail');
+            }
+        });
+
+        it('calls create channel and waits for connection', async () => {
+            try {
+                assert.calledTwice(connection.on);
+                assert.calledOnce(connection.createChannel);
+                assert.calledOnce(connection.createChannel().waitForConnect);
+            } catch (error) {
+                throw new Error('should not fail');
+            }
+        });
+
+        it('does not call publish messages', async () => {
+            try {
+                assert.notCalled(connection.createChannel().publish);
+            } catch (error) {
+                throw new Error('should not fail');
+            }
+        });
     });
+    describe('rabbitmq message consumer test with retry disabled', async () => {
+        beforeEach(async () => {
+            retryQMock = {
+                push: sinon.stub()
+            };
+            configObj.rabbitmq.retryQueueEnabled = false;
+            configMock = {
+                getConfig: () => configObj
+            };
+            ampqConnMock = new AmqpConnectionMock();
+            requestMock = sinon.stub();
 
-    it('calls create channel and waits for connection', async () => {
-        try {
-            assert.calledTwice(connection.on);
-            assert.calledOnce(connection.createChannel);
-            assert.calledOnce(connection.createChannel().waitForConnect);
-        } catch (error) {
-            throw new Error('should not fail');
-        }
-    });
+            mockery.registerMock('./lib/config', configMock);
+            mockery.registerMock('request', requestMock);
+            mockery.registerMock('amqp-connection-manager', ampqConnMock);
+            mockery.registerMock('./lib/helper', helperMock);
+            mockery.registerMock('./lib/retry-queue', retryQMock);
 
-    it('does not call publish messages', async () => {
-        try {
-            assert.notCalled(connection.createChannel().publish);
-        } catch (error) {
-            throw new Error('should not fail');
-        }
+            /* eslint-disable global-require */
+            const receiver = require('../receiver');
+
+            connection = await receiver.listen();
+        });
+
+        afterEach(() => {
+            mockery.deregisterAll();
+            mockery.resetCache();
+            process.removeAllListeners('SIGTERM');
+            connection = null;
+        });
+        it('creates a rabbitmq connection', async () => {
+            try {
+                assert.calledTwice(connection.on);
+                assert.notEqual(connection.createChannel, null);
+            } catch (error) {
+                throw new Error('should not fail');
+            }
+        });
+
+        it('calls create channel and waits for connection', async () => {
+            try {
+                assert.calledTwice(connection.on);
+                assert.calledOnce(connection.createChannel);
+                assert.calledOnce(connection.createChannel().waitForConnect);
+            } catch (error) {
+                throw new Error('should not fail');
+            }
+        });
+
+        it('does not call publish messages', async () => {
+            try {
+                assert.notCalled(connection.createChannel().publish);
+            } catch (error) {
+                throw new Error('should not fail');
+            }
+        });
     });
 });


### PR DESCRIPTION
## Context

The value of RABBITMQ_RETRYQUEUE_ENABLED is not read as boolean, so it is enabled even if false is set.
Even if the Retry Queue feature is disabled, it will try to connect to the default retryQueue (sdRetryQueue), so it will output an error log many times.

## Objective

This PR adds check for retry enabled flag and does not connect to retry queue by default

## References

https://github.com/screwdriver-cd/screwdriver/issues/2491#issuecomment-938378922

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
