### PR TITLE
feat(#1658): Add flag for hab install

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -113,6 +113,7 @@ executor:
             # in milliseconds
             retryDelay: REQUEST_RETRYDELAY
             maxAttempts: REQUEST_MAXATTEMPTS
+        sdHabEnabled: SD_HAB_ENABLED
     k8s-sandbox:
       pluginName: k8s
       options:
@@ -207,6 +208,7 @@ executor:
             # in milliseconds
             retryDelay: REQUEST_RETRYDELAY
             maxAttempts: REQUEST_MAXATTEMPTS
+        sdHabEnabled: SD_HAB_ENABLED
     k8s-vm:
       weightage: WEIGHT_K8S_VM
       options:
@@ -280,6 +282,7 @@ executor:
             # in milliseconds
             retryDelay: REQUEST_RETRYDELAY
             maxAttempts: REQUEST_MAXATTEMPTS
+        sdHabEnabled: SD_HAB_ENABLED
     jenkins:
       weightage: WEIGHT_JENKINS
       options:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -73,6 +73,7 @@ executor:
             # in milliseconds
             retryDelay: 3000
             maxAttempts: 5
+        sdHabEnabled: yes
     k8s-sandbox:
       pluginName: k8s
       options:
@@ -135,6 +136,7 @@ executor:
             # in milliseconds
             retryDelay: 3000
             maxAttempts: 5
+        sdHabEnabled: yes
     k8s-vm:
       pluginName: k8s-vm
       weightage: 0
@@ -188,6 +190,7 @@ executor:
             # in milliseconds
             retryDelay: 3000
             maxAttempts: 5
+        sdHabEnabled: yes
 #     jenkins:
 #       options:
 #         # Configuration of Jenkins

--- a/package.json
+++ b/package.json
@@ -6,12 +6,11 @@
   "scripts": {
     "pretest": "eslint .",
     "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
-    "start": "node index.js",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/buildcluster-queue-worker.git"
+    "url": "git+https://github.com:screwdriver-cd/buildcluster-queue-worker.git"
   },
   "homepage": "https://github.com/screwdriver-cd/buildcluster-queue-worker",
   "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
@@ -58,9 +57,6 @@
     "threads": "^0.12.1"
   },
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "debug": false
   }
 }


### PR DESCRIPTION
## Context

Habitat installation needs to be optional for the launcher

## Objective

This PR adds the flag `SD_HAB_ENABLED` to the executor's configuration

## References

https://github.com/screwdriver-cd/launcher/pull/429
https://github.com/screwdriver-cd/executor-k8s/pull/178

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
