### PR TITLE
fix: create package-lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Install Screwdriver build cluster queue worker
-RUN npm install screwdriver-buildcluster-queue-worker@$VERSION --no-package-lock
+RUN npm install screwdriver-buildcluster-queue-worker@$VERSION
 WORKDIR /usr/src/app/node_modules/screwdriver-buildcluster-queue-worker
 
 # Run the service


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
[The previous PR](https://github.com/screwdriver-cd/buildcluster-queue-worker/pull/98) disabled package-lock.json, but package-lock.json is useful for clarifying the package version in the image, so re-enable it. 

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
package-lock.json is placed in the image.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
