### PR TITLE
fix(2491): health check processing error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 'use strict';
 
-(async() => {
-    const conf = require('config');
-    const httpdConfig = conf.get('httpd'); // Setup HTTPd
-    const server = require('./lib/server');
-    const receiver = require('./receiver');
+const conf = require('config');
+const httpdConfig = conf.get('httpd'); // Setup HTTPd
+const server = require('./lib/server');
+const receiver = require('./receiver');
+
+(async () => {
     const connection = await receiver.listen();
 
     server(httpdConfig, connection);
 })();
-

--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 'use strict';
 
-const conf = require('config');
-const httpdConfig = conf.get('httpd'); // Setup HTTPd
-const server = require('./lib/server');
-const receiver = require('./receiver');
-const connection = receiver.listen();
+(async() => {
+    const conf = require('config');
+    const httpdConfig = conf.get('httpd'); // Setup HTTPd
+    const server = require('./lib/server');
+    const receiver = require('./receiver');
+    const connection = await receiver.listen();
 
-server(httpdConfig, connection);
+    server(httpdConfig, connection);
+})();
+


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When connecting to RabbitMQ, the following error message displayed. 
```
Debug: internal, implementation, error 
    TypeError: amqpConnection.isConnected is not a function
    at handler (/usr/src/app/node_modules/screwdriver-buildcluster-queue-worker/lib/server.js:30:40)
```
The reason for this is simple: you have not await the [promise](https://github.com/screwdriver-cd/buildcluster-queue-worker/blob/7c410ba66da15bd2868f9743ca7197938d95c08b/receiver.js#L218).
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Correct use of `async/await`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2491#issuecomment-940697541

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
