### PR TITLE
fix: do not requeue when executor returns 403 or 404 error

### DIFF
--- a/receiver.js
+++ b/receiver.js
@@ -118,7 +118,6 @@ const onMessage = data => {
                     thread.kill();
                     if (['403', '404'].includes(error.message.substring(0, 3))) {
                         channelWrapper.ack(data);
-                        console.log('DEBUG: error handling');
 
                         return;
                     }

--- a/receiver.js
+++ b/receiver.js
@@ -115,6 +115,14 @@ const onMessage = data => {
                     thread.kill();
                 })
                 .on('error', async error => {
+                    thread.kill();
+                    if (['403', '404'].includes(error.message.substring(0, 3))) {
+                        channelWrapper.ack(data);
+                        console.log('DEBUG: error handling');
+
+                        return;
+                    }
+
                     if (retryCount >= messageReprocessLimit) {
                         logger.info(`acknowledge, max retries exceeded for ${job}`);
                         try {
@@ -131,7 +139,6 @@ const onMessage = data => {
                         );
                         channelWrapper.nack(data, false, false);
                     }
-                    thread.kill();
                 })
                 .on('exit', () => {
                     logger.info(`thread terminated for ${job} `);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

When `executor.start` returns 403/404 error, then buildcluster-queue-worker requeue the job, but the executor will return 403/404 error again when retry the job.
Thus it will requeue up to the `messageReprocessLimit`, and the queue will be jammed.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Make the job is not requeued when executor returns 403/404 error.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
