### PR TITLE
add: exit code to info log

### DIFF
--- a/receiver.js
+++ b/receiver.js
@@ -139,8 +139,9 @@ const onMessage = data => {
                         channelWrapper.nack(data, false, false);
                     }
                 })
-                .on('exit', () => {
+                .on('exit', (exitCode) => {
                     logger.info(`thread terminated for ${job} `);
+                    logger.info(`thread exit code: ${exitCode} `);
                 });
         }
     } catch (err) {
@@ -208,8 +209,9 @@ const onRetryMessage = async data => {
                 }
                 thread.kill();
             })
-            .on('exit', () => {
+            .on('exit', (exitCode) => {
                 logger.info(`thread terminated for ${job} `);
+                logger.info(`thread exit code: ${exitCode} `);
             });
     } catch (err) {
         logger.error(`${retryQueue}: error ${err}, acknowledge data: ${data} payload: ${data.content} `);

--- a/receiver.js
+++ b/receiver.js
@@ -139,9 +139,8 @@ const onMessage = data => {
                         channelWrapper.nack(data, false, false);
                     }
                 })
-                .on('exit', (exitCode) => {
-                    logger.info(`thread terminated for ${job} `);
-                    logger.info(`thread exit code: ${exitCode} `);
+                .on('exit', exitCode => {
+                    logger.info(`thread exit code ${exitCode} terminated for ${job}`);
                 });
         }
     } catch (err) {
@@ -209,9 +208,8 @@ const onRetryMessage = async data => {
                 }
                 thread.kill();
             })
-            .on('exit', (exitCode) => {
-                logger.info(`thread terminated for ${job} `);
-                logger.info(`thread exit code: ${exitCode} `);
+            .on('exit', exitCode => {
+                logger.info(`thread exit code ${exitCode} terminated for ${job}`);
             });
     } catch (err) {
         logger.error(`${retryQueue}: error ${err}, acknowledge data: ${data} payload: ${data.content} `);


### PR DESCRIPTION
## Context
We have found that the buildcluster-queue-worker is occasionally killed due to OOM when the number of parallel builds is high. 
Since the current log information does not allow us to determine whether the failure was due to OOM, we will add an exit code to the log so that the cause of failure can be identified from the log.

The exit code will be null if an OOM occurs, and 143(SIGTERM) if not.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- add exit code to log
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
