### PR TITLE
feat(3171): Move pipeline template workflowGraph out of config into a new field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-buildcluster-queue-worker",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "An amqp connection manager implementation that consumes jobs from Rabbitmq queue.",
   "main": "index.js",
   "scripts": {
@@ -49,9 +49,9 @@
     "fs": "0.0.2",
     "fs-extra": "^11.1.0",
     "path": "^0.12.7",
-    "screwdriver-executor-k8s": "^15.0.13",
-    "screwdriver-executor-k8s-vm": "^4.3.3",
-    "screwdriver-executor-router": "^3.0.1",
+    "screwdriver-executor-k8s": "^16.0.0",
+    "screwdriver-executor-k8s-vm": "^5.0.0",
+    "screwdriver-executor-router": "^4.0.0",
     "screwdriver-logger": "^2.0.0",
     "screwdriver-request": "^2.0.1",
     "threads": "^0.12.1"


### PR DESCRIPTION
BREAKING CHANGE: Move workflowGraph out of config and keep it at the same level as config


## Context
Move pipeline template workflowGraph out of config into a new field

## Objective

Upgrading dependencies

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
