### PR TITLE
Revert "fix(3055): remove k8s-vm dependence"

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -209,6 +209,80 @@ executor:
             retryDelay: REQUEST_RETRYDELAY
             maxAttempts: REQUEST_MAXATTEMPTS
         sdHabEnabled: SD_HAB_ENABLED
+    k8s-vm:
+      weightage: WEIGHT_K8S_VM
+      options:
+        # Configuration of Docker
+        kubernetes:
+            # The host or IP of the kubernetes cluster
+            host: K8S_HOST
+            # Privileged mode, default restricted, set to true for trusted container runtime use-case
+            privileged: K8S_SECURITYCONTEXT_PRIVILEGED
+            # The jwt token used for authenticating kubernetes requests
+            token: K8S_TOKEN
+            jobsNamespace: K8S_JOBS_NAMESPACE
+            baseImage: K8S_BASE_IMAGE
+            # Resources for build pod
+            resources:
+                # Number of cpu cores
+                cpu:
+                    micro: K8S_CPU_MICRO
+                    low: K8S_CPU_LOW
+                    high: K8S_CPU_HIGH
+                    turbo: K8S_CPU_TURBO
+                    # upper bound for user custom cpu
+                    max: K8S_CPU_MAX
+                # Memory in GB
+                memory:
+                    micro: K8S_MEMORY_MICRO
+                    low: K8S_MEMORY_LOW
+                    high: K8S_MEMORY_HIGH
+                    turbo: K8S_MEMORY_TURBO
+                    # upper bound for user custom memory
+                    max: K8S_MEMORY_MAX
+                disk:
+                  space: K8S_DISK_LABEL
+                  speed: K8S_DISK_SPEED_LABEL
+            # Default build timeout for all builds in this cluster
+            buildTimeout: K8S_VM_BUILD_TIMEOUT
+            # Default max build timeout
+            maxBuildTimeout: K8S_VM_MAX_BUILD_TIMEOUT
+            # Termination Grace period:
+            terminationGracePeriodSeconds: TERMINATION_GRACE_PERIOD_SECONDS
+            # k8s pod labels for cluster settings
+            # eg: { network-egress: 'restricted' } to execute builds where public internet access is blocked by default
+            podLabels:
+              __name: K8S_POD_LABELS
+              __format: json
+            # k8s node selectors for appropriate build pod scheduling.
+            # Value is Object of format { label: 'value' } See
+            # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node
+            # Eg: { dedicated: 'screwdriver' } to schedule pods on nodes having
+            # label-value of dedicated=screwdriver
+            nodeSelectors:
+              __name: K8S_VM_NODE_SELECTORS
+              __format: json
+            # k8s preferred node selectors for build pod scheduling
+            # See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
+            preferredNodeSelectors:
+              __name: K8S_VM_PREFERRED_NODE_SELECTORS
+              __format: json
+        # Launcher image to use
+        launchImage: LAUNCH_IMAGE
+        # Launcher container tag to use
+        launchVersion: LAUNCH_VERSION
+        # Prefix to the container
+        prefix: EXECUTOR_PREFIX
+        # Circuit breaker config
+        fusebox:
+            breaker:
+                # in milliseconds
+                timeout: CIRCUIT_TIMEOUT
+        requestretry:
+            # in milliseconds
+            retryDelay: REQUEST_RETRYDELAY
+            maxAttempts: REQUEST_MAXATTEMPTS
+        sdHabEnabled: SD_HAB_ENABLED
     jenkins:
       weightage: WEIGHT_JENKINS
       options:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,7 +1,7 @@
 ---
 executor:
     # Default executor
-    plugin: k8s
+    plugin: k8s-vm
     k8s:
       pluginName: k8s
       exclusion:
@@ -125,6 +125,60 @@ executor:
           # Launcher image to use
         launchImage: screwdrivercd/launcher
         # Container tags to use
+        launchVersion: stable
+        # Circuit breaker config
+        fusebox:
+            breaker:
+                # in milliseconds
+                timeout: 10000
+        # requestretry configs
+        requestretry:
+            # in milliseconds
+            retryDelay: 3000
+            maxAttempts: 5
+        sdHabEnabled: true
+    k8s-vm:
+      pluginName: k8s-vm
+      weightage: 0
+      options:
+        # Configuration of Docker
+        kubernetes:
+            # The host or IP of the kubernetes cluster
+            host: kubernetes.default
+            # Privileged mode, default restricted, set to true for trusted container runtime use-case
+            privileged: false
+            # Resources for build pod
+            resources:
+                cpu:
+                    # Number of cpu cores
+                    micro: 1
+                    low: 2
+                    high: 6
+                    turbo: 12
+                    # upper bound for user custom cpu
+                    max: 12
+                memory:
+                    # Memory in GB
+                    micro: 1
+                    low: 2
+                    high: 12
+                    turbo: 16
+                    # upper bound for user custom memory
+                    max: 16
+            # Default build timeout for all builds in this cluster
+            buildTimeout: 90
+            # Default max build timeout
+            maxBuildTimeout: 120
+            # Termination Grace period defaulted to 60 seconds
+            terminationGracePeriodSeconds: 60
+            # k8s pod labels for cluster settings
+            podLabels: {}
+            # k8s node selectors for appropriate pod scheduling
+            nodeSelectors: {}
+            preferredNodeSelectors: {}
+        # Launcher image to use
+        launchImage: screwdrivercd/launcher
+        # Launcher container tag to use
         launchVersion: stable
         # Circuit breaker config
         fusebox:

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "fs-extra": "^11.1.0",
     "path": "^0.12.7",
     "screwdriver-executor-k8s": "^16.0.0",
+    "screwdriver-executor-k8s-vm": "^5.0.0",
     "screwdriver-executor-router": "^4.0.0",
     "screwdriver-logger": "^2.0.0",
     "screwdriver-request": "^2.0.1",

--- a/test/data/executorConfig.json
+++ b/test/data/executorConfig.json
@@ -1,5 +1,5 @@
 {
-    "plugin": "k8s-test",
+    "plugin": "k8s-vm",
     "k8s": {
         "options": {
             "kubernetes": {
@@ -43,7 +43,7 @@
             }
         }
     },
-    "k8s-test": {
+    "k8s-vm": {
         "options": {
             "kubernetes": {
                 "host": "kubernetes.default",

--- a/test/data/executorConfigWeightage.json
+++ b/test/data/executorConfigWeightage.json
@@ -1,5 +1,5 @@
 {
-    "plugin": "k8s-test",
+    "plugin": "k8s-vm",
     "k8s": {
         "weightage": 20,
         "options": {
@@ -44,7 +44,7 @@
             }
         }
     },
-    "k8s-test": {
+    "k8s-vm": {
         "weightage": 10,
         "options": {
             "kubernetes": {

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -162,11 +162,11 @@ describe('Jobs Test', () => {
             });
         });
 
-        it('starts a job with executor annotations k8s-test and not weighted', () => {
+        it('starts a job with executor annotations k8s-vm and not weighted', () => {
             mockExecutor.start.resolves(null);
             const overrideBuildConfig = Object.assign(anotherBuildConfig.buildConfig, {
                 annotations: {
-                    'beta.screwdriver.cd/executor': 'k8s-test'
+                    'beta.screwdriver.cd/executor': 'k8s-vm'
                 }
             });
             const job = `jobId: ${overrideBuildConfig.buildId}, jobType: 'start', buildId: ${overrideBuildConfig.buildId}`;


### PR DESCRIPTION
Reverts screwdriver-cd/buildcluster-queue-worker#160

We are still seeing some use cases of `k8s-vm` so we cannot really remove this dependency right now.