### PR TITLE
fix: functional-test run on the node.js image

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -47,14 +47,14 @@ jobs:
     # functional test
     functional-test:
       requires: beta
-      image: centos:centos7
+      image: node:22
       environment:
         PIPELINE_ID: 8188
         INSTANCE: "https://beta.api.screwdriver.cd"
         NAMESPACE: v4
         TIMEOUT: 30
+        USER_SHELL_BIN: /bin/bash
       steps:
-        - install_jq: yum install epel-release -y && yum update -y && yum install jq -y && jq -Version
         - trigger_beta_functional_test: |
             TOKEN=$(curl -s -S -m ${TIMEOUT} --fail ${INSTANCE}/${NAMESPACE}/auth/token?api_token=${BETA_FT_ACCESS_TOKEN} | jq -r '.token')
             [[ -z "$TOKEN" ]] && echo "empty Token" && exit 1


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
functional-test has been failing for a long time with jq install.
https://cd.screwdriver.cd/pipelines/1825/builds/971322/steps/install_jq

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Change the build image to `node:22` which does not require jq installation.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
