### PR TITLE
feat: Add scheduling improvement and a message processing workflow doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@
 npm install screwdriver-buildcluster-queue-worker
 ```
 
+## Build Start Workflow
+
+The queue worker processes build start messages from RabbitMQ and manages pod lifecycle in Kubernetes.
+
+> **See [WORKFLOW.md](WORKFLOW.md) for detailed workflow diagram with retry behavior**
+
+### Configuration
+
+- `prefetchCount`: 20 messages per worker (default)
+- `buildInitTimeout`: 5 minutes (default)
+- `messageReprocessLimit`: 5 retries in retry queue (default)
+
 ## Testing
 
 ```bash

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,166 @@
+# Build Start Workflow - Detailed Flow
+
+## Main Queue Processing
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ MAIN QUEUE: Message Processing                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+    ┌──────────────────┐
+    │ Receive Message  │
+    │ (prefetch=20)    │
+    └────────┬─────────┘
+             │
+             ├─────────────────────────────────────────────────────────┐
+             │                                                         │
+    ┌────────▼─────────┐                                    ┌─────────▼─────────┐
+    │ Start Timeout    │                                    │ Spawn Thread      │
+    │ (5 min timer)    │                                    │ Call _start()     │
+    └──────────────────┘                                    └─────────┬─────────┘
+             │                                                         │
+             │                                              ┌──────────▼──────────┐
+             │                                              │ Try Create K8s Pod  │
+             │                                              │ (POST to K8s API)   │
+             │                                              └──────────┬──────────┘
+             │                                                         │
+             │                                    ┌────────────────────┼───────────────┐
+             │                                    │                    │               │
+             │                         ┌──────────▼─────────┐  ┌──────▼─────────────────────┐
+             │                         │ Success (201)      │  │ API Error (500/503/etc)    │
+             │                         │ Pod Created!       │  │ Network error, K8s down    │
+             │                         └──────────┬─────────┘  └──────┬─────────────────────┘
+             │                                    │                    │
+             │                         ┌──────────▼──────────────┐  ┌─▼──────────────────────┐
+             │                         │ Check Pod Status        │  │ THROW EXCEPTION        │
+             │                         │ (GET pod/status)        │  │ "Failed to create pod" │
+             │                         └──────────┬──────────────┘  └─┬──────────────────────┘
+             │                                    │                    │
+             │                      ┌─────────────┼─────────────┐      │ .on('error')
+             │                      │             │             │      │
+             │           ┌──────────▼─────┐  ┌───▼───┐  ┌─────▼──────┐▼──────────────────┐
+             │           │ Pod Status:    │  │ Pod:  │  │ Pod Status:││ Retry < 5?       │
+             │           │ pending/running│  │failed │  │ unknown    ││ YES: NACK (retry)│
+             │           └──────────┬─────┘  └───┬───┘  └─────┬──────┘│ NO: FAILURE+ACK  │
+             │                      │            │             │       └──────────────────┘
+             │           ┌──────────▼─────┐  ┌───▼─────────────▼───┐
+             │           │ Return TRUE    │  │ Return FALSE         │
+             │           │ "Pod OK"       │  │ "Status check failed"│
+             │           └──────────┬─────┘  └───┬──────────────────┘
+             │                      │            │
+             │           ┌──────────▼─────┐  ┌───▼──────────────┐
+             │           │ ACK message    │  │ Clear timeout    │
+             │           │ (free prefetch)│  │ ACK message      │
+             │           └──────────┬─────┘  │ Push to RETRY    │
+             │                      │        │ QUEUE (verify)   │
+             │           ┌──────────▼─────┐  └───┬──────────────┘
+             │           │ DON'T clear    │      │
+             │           │ timeout!       │      │
+             │           │ (keep monitor) │      │
+             │           └──────────┬─────┘      │
+             │                      │            │
+             │◄─────────────────────┘            │
+             │                                   │
+    ┌────────▼─────────┐                        │
+    │ Wait 5 minutes   │                        │
+    └────────┬─────────┘                        │
+             │                                   │
+    ┌────────▼───────────────────────┐          │
+    │ Timeout Fires!                 │          │
+    │ Update build statusmessage:    │          │
+    │ "Build initialization delayed" │          │
+    └────────┬───────────────────────┘          │
+             │                                   │
+    ┌────────▼─────────┐                        │
+    │ Push to          │◄───────────────────────┘
+    │ RETRY QUEUE      │
+    └────────┬─────────┘
+             │
+             │
+┌────────────▼─────────────────────────────────────────────────────────────────┐
+│ RETRY QUEUE: Pod Verification                                                │
+└──────────────────────────────────────────────────────────────────────────────┘
+
+    ┌────────────────────┐
+    │ Receive Message    │
+    │ from Retry Queue   │
+    └─────────┬──────────┘
+              │
+    ┌─────────▼──────────┐
+    │ Spawn Thread       │
+    │ Call _verify()     │
+    └─────────┬──────────┘
+              │
+    ┌─────────▼────────────────┐
+    │ Try Get Pod Status       │
+    │ (GET pods?labelSelector) │
+    └─────────┬────────────────┘
+              │
+    ┌─────────┼────────────────────────────┐
+    │         │                            │
+┌───▼─────────────┐              ┌─────────▼────────────────┐
+│ Success         │              │ API Error (K8s API down) │
+│ Got pod status  │              │ Network issue            │
+└───┬─────────────┘              └─────────┬────────────────┘
+    │                                      │
+    │                            ┌─────────▼────────────────┐
+    │                            │ THROW EXCEPTION          │
+    │                            │ .on('error')             │
+    │                            └─────────┬────────────────┘
+    │                                      │
+    │                            ┌─────────▼────────────────┐
+    │                            │ Retry < 5?               │
+    │                            │ YES: NACK (retry verify) │
+    │                            │ NO: FAILURE + ACK        │
+    │                            └──────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Check Pod Status & Container Waiting Reason                     │
+└─────────┬────────────────────────────────────────────────────────┘
+          │
+    ┌─────┴──────────┬────────────────┬───────────────┬─────────────────┐
+    │                │                │               │                 │
+┌───▼────────────┐  ┌▼──────────┐  ┌─▼────────────┐ ┌▼───────────────┐ ┌▼──────────────┐
+│ Pod Status:    │  │ Pod:      │  │ Pod:         │ │ Pod:           │ │ Pod:          │
+│ running/       │  │ failed/   │  │ pending +    │ │ pending +      │ │ pending +     │
+│ succeeded      │  │ unknown   │  │ ErrImagePull │ │ CrashLoopBack  │ │ PodInitializing│
+└───┬────────────┘  └┬──────────┘  └─┬────────────┘ └┬───────────────┘ └┬──────────────┘
+    │                │                │               │                  │
+┌───▼────────────┐  ┌▼────────────────────────────────▼──────────────────▼──────────────┐
+│ Return EMPTY   │  │ Return ERROR MESSAGE                                               │
+│ (success)      │  │ "Build failed to start..."                                         │
+└───┬────────────┘  └┬───────────────────────────────────────────────────────────────────┘
+    │                │                                   │
+┌───▼────────────┐  ┌▼────────────────┐      ┌─────────▼──────────┐
+│ ACK message    │  │ Update build to │      │ Return EMPTY       │
+│ (build OK)     │  │ FAILURE         │      │ (allow more time   │
+└────────────────┘  │ ACK message     │      │ for image pull)    │
+                    └─────────────────┘      └─────────┬──────────┘
+                                                       │
+                                             ┌─────────▼──────────┐
+                                             │ ACK message        │
+                                             │ (pod still healthy │
+                                             │ may take 10+ min)  │
+                                             └────────────────────┘
+```
+
+## Key Points
+
+### Main Queue Retries (NACK):
+- **When**: Pod creation throws exception (K8s API error, network issue)
+- **Why**: Pod was never created, safe to retry
+- **How many**: Up to 5 times via RabbitMQ requeue
+- **After max retries**: Update build to FAILURE and ACK
+
+### Retry Queue Retries (NACK):
+- **When**: _verify() throws exception (can't get pod status from K8s)
+- **Why**: Transient API issue, pod might be fine
+- **How many**: Up to 5 times via RabbitMQ requeue
+- **After max retries**: Update build to FAILURE and ACK
+
+### No Retries (ACK immediately):
+- Pod created successfully (pending/running status) → main queue
+- Pod status check failed (pod exists but failed/unknown) → main queue → retry queue
+- Verify detects failed pod (returns error message) → retry queue
+- Verify detects healthy pod (returns empty) → retry queue

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -363,6 +363,8 @@ rabbitmq:
     retryQueueEnabled: RABBITMQ_RETRYQUEUE_ENABLED
     # Exchange / router name for rabbitmq
     exchange: RABBITMQ_EXCHANGE
+    # build pod initialization timeout
+    initTimeout: RABBITMQ_BUILD_INIT_TIMEOUT
 httpd:
   # Port to listen on
   port: PORT

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -247,6 +247,8 @@ rabbitmq:
     retryQueueEnabled: false
     # Exchange / router name for rabbitmq
     exchange: build
+    # build pod initialization timeout in minutes
+    initTimeout: "5"
 httpd:
     # Port to listen on
     port: 80

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,7 +19,8 @@ const {
     messageReprocessLimit,
     retryQueue,
     retryQueueEnabled,
-    exchange
+    exchange,
+    initTimeout
 } = rabbitmqConfig;
 const amqpURI = `${protocol}://${username}:${password}@${host}:${port}${vhost}`;
 
@@ -58,7 +59,8 @@ function getConfig() {
         cachePath: path,
         retryQueue,
         retryQueueEnabled: convertToBool(retryQueueEnabled),
-        exchange
+        exchange,
+        initTimeout: Number(initTimeout) || 5
     };
 }
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -12,14 +12,19 @@ const request = require('screwdriver-request');
  */
 async function updateBuildStatusAsync(config, status, statusMessage) {
     const { buildId } = config;
+    const payload = {};
+
+    if (status) {
+        payload.status = status;
+    }
+    if (statusMessage) {
+        payload.statusMessage = statusMessage;
+    }
 
     return request({
         method: 'PUT',
         url: `${config.apiUri}/v4/builds/${buildId}`,
-        json: {
-            status,
-            statusMessage
-        },
+        json: payload,
         context: {
             token: config.token
         }

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -50,7 +50,8 @@ describe('config test', () => {
             cachePath: configDef.ecosystem.cache.path,
             retryQueue: configDef.rabbitmq.retryQueue,
             retryQueueEnabled: configDef.rabbitmq.retryQueueEnabled,
-            exchange: configDef.rabbitmq.exchange
+            exchange: configDef.rabbitmq.exchange,
+            initTimeout: configDef.rabbitmq.initTimeout || 5 // default value
         });
     });
 });

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -38,7 +38,8 @@ describe('rabbitmq message consumer', async () => {
             prefetchCount: 20,
             messageReprocessLimit: 3,
             retryQueue: 'rq',
-            retryQueueEnabled: true
+            retryQueueEnabled: true,
+            initTimeout: 5
         }
     };
 
@@ -174,6 +175,62 @@ describe('rabbitmq message consumer', async () => {
             } catch (error) {
                 throw new Error('should not fail');
             }
+        });
+    });
+
+    describe('initTimeout configuration', () => {
+        let configLib;
+
+        beforeEach(() => {
+            // Use the real config module to test initTimeout
+            mockery.disable();
+            configLib = require('../lib/config');
+        });
+
+        afterEach(() => {
+            mockery.enable({
+                useCleanCache: true,
+                warnOnUnregistered: false
+            });
+        });
+
+        it('includes initTimeout in config with default value', () => {
+            const config = configLib.getConfig();
+
+            assert.isDefined(config.initTimeout);
+            assert.isNumber(config.initTimeout);
+            assert.equal(config.initTimeout, 5);
+        });
+
+        it('validates initTimeout is positive number', () => {
+            const config = configLib.getConfig();
+
+            assert.isNumber(config.initTimeout);
+            assert.isAbove(config.initTimeout, 0);
+        });
+
+        it('includes initTimeout when retry queue is enabled', () => {
+            const config = configLib.getConfig();
+
+            assert.isDefined(config.retryQueueEnabled);
+            assert.isDefined(config.initTimeout);
+        });
+
+        it('verifies timeout value is in minutes', () => {
+            const config = configLib.getConfig();
+            const timeoutInMs = config.initTimeout * 60 * 1000;
+
+            assert.equal(timeoutInMs, 300000);
+        });
+
+        it('verifies config structure includes all required fields', () => {
+            const config = configLib.getConfig();
+
+            assert.isDefined(config.amqpURI);
+            assert.isDefined(config.queue);
+            assert.isDefined(config.prefetchCount);
+            assert.isDefined(config.messageReprocessLimit);
+            assert.isDefined(config.initTimeout);
         });
     });
 });


### PR DESCRIPTION
## Context

The build queue worker has a retry amplification issue where failed pods are retried up to 10 times (5 main queue + 5 retry queue), and pods that get stuck after creation are never detected because the timeout is cleared immediately when _start() completes

## Objective

This PR eliminates retry amplification and improves pod failure detection:
Timeout now persists for successful pod creations to detect stuck pods
Timeout only cleared for immediate failures (pushed to retry queue right away)
All messages acked immediately to free prefetch slots
Also added workflow documentation

## References

https://github.com/screwdriver-cd/executor-k8s/pull/209

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
