### PR TITLE
fix: update build failure and error message on 403/404 error

### DIFF
--- a/receiver.js
+++ b/receiver.js
@@ -124,6 +124,13 @@ const onMessage = data => {
                 .on('error', async error => {
                     thread.kill();
                     if (['403', '404'].includes(error.message.substring(0, 3))) {
+                        logger.info(`Non-retryable error for ${job}: ${error.message}`);
+                        try {
+                            await helper.updateBuildStatusAsync(buildConfig, 'FAILURE', error.message);
+                            logger.info(`Build status updated to FAILURE for build ${buildId}`);
+                        } catch (err) {
+                            logger.error(`Failed to update build status to FAILURE for build:${buildId}:${err}`);
+                        }
                         channelWrapper.ack(data);
 
                         return;

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -178,6 +178,106 @@ describe('rabbitmq message consumer', async () => {
         });
     });
 
+    describe('onMessage 403/404 error handling logic', () => {
+        let updateBuildStatusMock;
+
+        beforeEach(() => {
+            updateBuildStatusMock = sinon.stub().resolves();
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('updates build status to FAILURE on 403 error', async () => {
+            const buildConfig = {
+                jobId: 1234,
+                buildId: 5678,
+                apiUri: 'https://api.screwdriver.cd',
+                token: 'fake-token'
+            };
+
+            // Simulate error message that starts with '403'
+            const error403 = new Error('403 Reason "admission webhook denied the request"');
+            const errorMessage = error403.message;
+
+            // This is the logic from receiver.js onMessage error handler
+            if (['403', '404'].includes(errorMessage.substring(0, 3))) {
+                await updateBuildStatusMock(buildConfig, 'FAILURE', errorMessage);
+            }
+
+            assert.calledOnce(updateBuildStatusMock);
+            assert.calledWith(updateBuildStatusMock, buildConfig, 'FAILURE', errorMessage);
+        });
+
+        it('updates build status to FAILURE on 404 error', async () => {
+            const buildConfig = {
+                jobId: 1234,
+                buildId: 5678,
+                apiUri: 'https://api.screwdriver.cd',
+                token: 'fake-token'
+            };
+
+            const error404 = new Error('404 Not Found - resource does not exist');
+            const errorMessage = error404.message;
+
+            if (['403', '404'].includes(errorMessage.substring(0, 3))) {
+                await updateBuildStatusMock(buildConfig, 'FAILURE', errorMessage);
+            }
+
+            assert.calledOnce(updateBuildStatusMock);
+            assert.calledWith(updateBuildStatusMock, buildConfig, 'FAILURE', errorMessage);
+        });
+
+        it('does not match 403 check when error message does not start with 403', async () => {
+            const buildConfig = {
+                jobId: 1234,
+                buildId: 5678,
+                apiUri: 'https://api.screwdriver.cd',
+                token: 'fake-token'
+            };
+
+            // Error message that does NOT start with '403'
+            const errorOther = new Error('Failed to create pod: some error');
+            const errorMessage = errorOther.message;
+
+            if (['403', '404'].includes(errorMessage.substring(0, 3))) {
+                await updateBuildStatusMock(buildConfig, 'FAILURE', errorMessage);
+            }
+
+            // Should NOT be called since error doesn't start with 403/404
+            assert.notCalled(updateBuildStatusMock);
+        });
+
+        it('handles updateBuildStatusAsync failure gracefully', async () => {
+            const buildConfig = {
+                jobId: 1234,
+                buildId: 5678,
+                apiUri: 'https://api.screwdriver.cd',
+                token: 'fake-token'
+            };
+
+            updateBuildStatusMock.rejects(new Error('API error'));
+
+            const error403 = new Error('403 Forbidden');
+            const errorMessage = error403.message;
+
+            let caughtError = null;
+
+            if (['403', '404'].includes(errorMessage.substring(0, 3))) {
+                try {
+                    await updateBuildStatusMock(buildConfig, 'FAILURE', errorMessage);
+                } catch (err) {
+                    caughtError = err;
+                }
+            }
+
+            assert.calledOnce(updateBuildStatusMock);
+            assert.isNotNull(caughtError);
+            assert.equal(caughtError.message, 'API error');
+        });
+    });
+
     describe('initTimeout configuration', () => {
         let configLib;
 


### PR DESCRIPTION
## Context

403/404 error from k8s api like admission controller error goes unnoticed and does not update build 

## Objective

Fix the case for 403/404 error and update build with Failure and error message

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
