### PR TITLE
fix: upgrade screwdriver-executor-k8s to 17.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "fs": "0.0.2",
     "fs-extra": "^11.1.0",
     "path": "^0.12.7",
-    "screwdriver-executor-k8s": "^17.3.3",
+    "screwdriver-executor-k8s": "^17.3.4",
     "screwdriver-executor-k8s-vm": "^5.0.0",
     "screwdriver-executor-router": "^5.0.0",
     "screwdriver-logger": "^3.0.0",


### PR DESCRIPTION
## Context

screwdriver-executor-k8s 17.3.4 includes the js-yaml v5 upgrade. The buildcluster queue worker must be released again to include the updated executor dependency.

## Objective

Upgrade screwdriver-executor-k8s from 17.3.3 to 17.3.4.

## References

- https://github.com/screwdriver-cd/screwdriver/issues/3510
- https://github.com/screwdriver-cd/executor-k8s/pull/214